### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ blocks** of a ``subdir`` are moved, leaving the datadirs in a proper state.
 
 # Monitoring
 
-Appart of the standard ``df -h`` command to monitor disks fulling in, the disk bandwidths can be easily monitored using ``iostat -x 1 -m``
+Apart of the standard ``df -h`` command to monitor disks fulling in, the disk bandwidths can be easily monitored using ``iostat -x 1 -m``
 
 ```
 $ iostat -x 1 -m


### PR DESCRIPTION
@killerwhile, I've corrected a typographical error in the documentation of the [volume-balancer](https://github.com/killerwhile/volume-balancer) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.